### PR TITLE
The Plugin Name was misspelled 🙈

### DIFF
--- a/wp-rocket-cli.php
+++ b/wp-rocket-cli.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Plugin Name: WR Rocket CLI
+ * Plugin Name: WP Rocket CLI
  * Plugin URI:
  * Description:
  * Version: 1.0


### PR DESCRIPTION
## Description

The plugin name was misspelled in the plugins comment block that WP uses to display the name of its installed plugins.

<img width="630" alt="wr-rocket" src="https://cloud.githubusercontent.com/assets/163182/19388452/b557401e-91ed-11e6-9355-cb50304ca4a7.png">
