### PR TITLE
Use "type": "wp-cli-package" to designate this as a WP-CLI package

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "GeekPress/wp-rocket-cli",
-    "type": "command",
+    "type": "wp-cli-package",
     "description": "Add a `wp rocket` command to support the WP Rocket plugin",
     "keywords": ["wp-cli", "rocket", "cache"],
     "homepage": "https://github.com/GeekPress/wp-rocket-cli",


### PR DESCRIPTION
See https://github.com/wp-cli/wp-cli/issues/2567
