### PR TITLE
Add option to trigger sitemap-based preloading

### DIFF
--- a/command.php
+++ b/command.php
@@ -239,14 +239,27 @@ class WPRocket_CLI extends WP_CLI_Command {
 	/**
 	 * Run WP Rocket Bot for preload cache files
 	 *
+	 * ## OPTIONS
+	 *
+	 * [--sitemap]
+	 * : Trigger sitemap-based preloading
+	 * 
 	 * ## EXAMPLES
 	 *
 	 *     wp rocket preload
+	 *     wp rocket preload --sitemap
 	 *
 	 * @subcommand preload
 	 */
 	public function preload( $args = array(), $assoc_args = array() ) {
-		run_rocket_bot( 'cache-preload' );
+	
+		if ( ! empty( $assoc_args['sitemap'] ) && $assoc_args['sitemap'] ) {
+			WP_CLI::line( 'Triggering sitemap-based preloading.' );
+			run_rocket_sitemap_preload();
+		} else {
+			WP_CLI::line( 'Triggering homepage-based preloading.' );
+			run_rocket_bot( 'cache-preload' );
+		}
 
 		WP_CLI::success( 'Finished WP Rocket preload cache files.' );
 	}


### PR DESCRIPTION
When WP Rocket is configured to preload cache from a sitemap, `wp rocket preload` does not trigger it. This simply adds an option `--sitemap`. Official documentation can be found [here](https://docs.wp-rocket.me/article/8-how-the-cache-is-preloaded#preloading-at-a-specific-time).