### PR TITLE
Closes #25 Clean command needs to clean minify folder

### DIFF
--- a/command.php
+++ b/command.php
@@ -82,7 +82,7 @@ class WPRocket_CLI extends WP_CLI_Command {
 	 *     wp rocket clean --post_id=2
 	 *     wp rocket clean --post_id=2,4,6,8
 	 *     wp rocket clean --permalink=http://example.com
-	 *     wp rocket clean --permalink=http://example.com, http://example.com/category/(.*)
+	 *     wp rocket clean --permalink=http://example.com,http://example.com/category/(.*)
 	 *     wp rocket clean --lang=fr
 	 *     wp rocket clean --lang=fr,de,en,it
 	 *     wp rocket clean --blog_id=2
@@ -112,6 +112,10 @@ class WPRocket_CLI extends WP_CLI_Command {
 				if ( $bloginfo = get_blog_details( (int) $blog_id, false ) ) {
 
 					switch_to_blog( $blog_id );
+
+					if ( ! is_plugin_active( 'wp-rocket/wp-rocket.php' ) ) {
+						continue;
+					}
 
 					rocket_clean_domain();
 					WP_CLI::line( 'Cache cleared for "' . esc_url( 'http://' . $bloginfo->domain . $bloginfo->path ) . '".' );
@@ -151,7 +155,7 @@ class WPRocket_CLI extends WP_CLI_Command {
 
 			foreach ( $langs as $lang ) {
 
-				rocket_clean_domain_for_selected_lang( $lang );
+				rocket_clean_domain( $lang );
 				$notify->tick();
 
 			}

--- a/command.php
+++ b/command.php
@@ -83,9 +83,9 @@ class WPRocket_CLI extends WP_CLI_Command {
 	 *     wp rocket clean --post_id=2,4,6,8
 	 *     wp rocket clean --permalink=http://example.com
 	 *     wp rocket clean --permalink=http://example.com, http://example.com/category/(.*)
-	 *	   wp rocket clean --lang=fr
+	 *     wp rocket clean --lang=fr
 	 *     wp rocket clean --lang=fr,de,en,it
-	 *	   wp rocket clean --blog_id=2
+	 *     wp rocket clean --blog_id=2
 	 *     wp rocket clean --blog_id=2,4,6,8
 	 *
 	 * @subcommand clean
@@ -115,6 +115,12 @@ class WPRocket_CLI extends WP_CLI_Command {
 
 					rocket_clean_domain();
 					WP_CLI::line( 'Cache cleared for "' . esc_url( 'http://' . $bloginfo->domain . $bloginfo->path ) . '".' );
+
+					// Remove all minify cache files.
+					rocket_clean_minify();
+					// Generate a new random key for minify cache file.
+					update_rocket_option( 'minify_css_key', create_rocket_uniqid() );
+					update_rocket_option( 'minify_js_key', create_rocket_uniqid() );
 
 					restore_current_blog();
 
@@ -268,16 +274,16 @@ class WPRocket_CLI extends WP_CLI_Command {
 	 *
 	 * [--file=<file>]
 	 * : The file to regenerate. It could be:
-	 *	- htaccess
-	 *	- advanced-cache
-	 *	- config (It's the config file stored in the wp-rocket-config folder)
+	 *  - htaccess
+	 *  - advanced-cache
+	 *  - config (It's the config file stored in the wp-rocket-config folder)
 	 *
 	 * [--nginx=<bool>]
 	 * : The command should run as if on nginx (setting the $is_nginx global to true)
 	 *
 	 * ## EXAMPLES
 	 *
-	 *	   wp rocket regenerate --file=htaccess
+	 *     wp rocket regenerate --file=htaccess
 	 *     wp rocket regenerate --file=config --nginx=true
 	 *
 	 * @subcommand regenerate

--- a/command.php
+++ b/command.php
@@ -233,6 +233,13 @@ class WPRocket_CLI extends WP_CLI_Command {
 			}
 
 			rocket_clean_domain();
+
+			// Remove all minify cache files.
+			rocket_clean_minify();
+			// Generate a new random key for minify cache file.
+			update_rocket_option( 'minify_css_key', create_rocket_uniqid() );
+			update_rocket_option( 'minify_js_key', create_rocket_uniqid() );
+
 			WP_CLI::success( 'All cache files cleared.' );
 
 		}


### PR DESCRIPTION
Closes https://github.com/wp-media/wp-rocket-cli/issues/25

I reproduced easily the issue and it simply needed to clean the minify folder and to regenerate the unique key for minify_css and minify_js.

