### PR TITLE
Fix #22 Activate/Deactivate does not trigger htaccess regeneration

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,8 @@ This repository contains a [WP-CLI command](https://github.com/wp-cli/wp-cli)  f
 
 Supported commands:
 
-* `wp rocket activate` -- Set WP_CACHE to true.
-* `wp rocket deactivate` -- Set WP_CACHE to false.
+* `wp rocket activate-cache` -- Set WP_CACHE to true, flush htaccess rules and clean WP Rocket cache.
+* `wp rocket deactivate-cache` -- Set WP_CACHE to false, flush htaccess rules and clean WP Rocket cache.
 * `wp rocket clean --post_id=<post_id> --permalink=<permalink> --lang=<lang> --blog_id=<blog_id>` -- Purge cache files.
 * `wp rocket clean --confirm` -- Purge cache files without prompting for confirmation (usefull for automation tools/scripts)
 * `wp rocket preload` -- Preload cache files.

--- a/command.php
+++ b/command.php
@@ -342,7 +342,7 @@ class WPRocket_CLI extends WP_CLI_Command {
 					WP_CLI::success( 'The config file has just been regenerated.' );
 					break;
 				case 'htaccess':
-					$GLOBALS['is_apache'] = true;
+					self::set_apache();
 					if ( flush_rocket_htaccess() ) {
 						WP_CLI::success( 'The .htaccess file has just been regenerated.' );
 					}else{

--- a/command.php
+++ b/command.php
@@ -26,6 +26,10 @@ class WPRocket_CLI extends WP_CLI_Command {
 	 * @subcommand activate-cache
 	 */
 	public function activate_cache() {
+		if ( ! is_plugin_active( 'wp-rocket/wp-rocket.php') ) {
+			WP_CLI::error( 'WP Rocket is not enabled.' );
+		}
+
 		if ( defined( 'WP_CACHE' ) && ! WP_CACHE ) {
 			$wp_cache = new WPCache( rocket_direct_filesystem() );
 
@@ -402,24 +406,6 @@ class WPRocket_CLI extends WP_CLI_Command {
 			default:
 			WP_CLI::error( 'The "enable" argument must contain either true or false value.' );
 				break;
-		}
-	}
-
-	/**
-	 * Clean WP Rocket domain and additional cache files.
-	 *
-	 * @param boolean $minify Clean also minify cache files.
-	 * @return void
-	 */
-	private function clean_wp_rocket_cache( $minify = false ) {
-		rocket_clean_domain();
-
-		if ( $minify ) {
-			// Remove all minify cache files.
-			rocket_clean_minify();
-			// Generate a new random key for minify cache file.
-			update_rocket_option( 'minify_css_key', create_rocket_uniqid() );
-			update_rocket_option( 'minify_js_key', create_rocket_uniqid() );
 		}
 	}
 

--- a/command.php
+++ b/command.php
@@ -41,7 +41,7 @@ class WPRocket_CLI extends WP_CLI_Command {
 			if ( $wp_cache->set_wp_cache_constant( true ) ) {
 				if ( rocket_valid_key() ) {
 					// Add All WP Rocket rules of the .htaccess file.
-					if ( isset( $assoc_args['htaccess'] ) && $assoc_args['htaccess'] ) {
+					if ( isset( $assoc_args['htaccess'] ) && 'true' === $assoc_args['htaccess'] ) {
 						self::set_apache();
 
 						if ( ! flush_rocket_htaccess() ) {
@@ -91,7 +91,7 @@ class WPRocket_CLI extends WP_CLI_Command {
 			if ( $wp_cache->set_wp_cache_constant( false ) ) {
 				if ( rocket_valid_key() ) {
 					// Remove All WP Rocket rules from the .htaccess file.
-					if ( isset( $assoc_args['htaccess'] ) && $assoc_args['htaccess'] ) {
+					if ( isset( $assoc_args['htaccess'] ) && 'true' === $assoc_args['htaccess'] ) {
 						self::set_apache();
 
 						if ( ! flush_rocket_htaccess( true ) ) {

--- a/command.php
+++ b/command.php
@@ -46,6 +46,8 @@ class WPRocket_CLI extends WP_CLI_Command {
 
 						if ( ! flush_rocket_htaccess() ) {
 							WP_CLI::warning( 'Adding WP Rocket rules to the htaccess file failed.');
+						} else {
+							WP_CLI::success( 'WP Rocket rules added to the htaccess file.');
 						}
 					}
 				}
@@ -96,6 +98,8 @@ class WPRocket_CLI extends WP_CLI_Command {
 
 						if ( ! flush_rocket_htaccess( true ) ) {
 							WP_CLI::warning( 'Removing WP Rocket rules from the htaccess file failed.');
+						} else {
+							WP_CLI::success( 'WP Rocket rules removed from the htaccess file.');
 						}
 					}
 				}

--- a/command.php
+++ b/command.php
@@ -87,6 +87,10 @@ class WPRocket_CLI extends WP_CLI_Command {
 	 * @subcommand deactivate-cache
 	 */
 	public function deactivate_cache( array $args = [], array $assoc_args = [] ) {
+		if ( ! is_plugin_active( 'wp-rocket/wp-rocket.php') ) {
+			WP_CLI::error( 'WP Rocket is not enabled.' );
+		}
+
 		if ( defined( 'WP_CACHE' ) && WP_CACHE ) {
 			$wp_cache = new WPCache( rocket_direct_filesystem() );
 


### PR DESCRIPTION
### Identify the issue
Activate / deactivate simply updates the constant `define('WP_CACHE', $value )`
However, during this operation, WP Rocket needs to apply some other mandatory changes like:
1. During Activation when WP_CACHE is set to true
-  Add All WP Rocket rules of the .htaccess file.
-  Delete current cache

2. During deactivation when WP_CACHE is set to false
- Delete All WP Rocket rules of the .htaccess file.
- Clean current cache

### Scope a solution
Rename both functions from `activate` => `activate-cache` and `deactivate` => `deactivate-cache` . This will make clear what is expected from this.
Update functions to do the expected 

### Estimate the effort
Effort `[XS]`