### PR TITLE
Update docblock to be shown when $ wp is invoked

### DIFF
--- a/command.php
+++ b/command.php
@@ -4,7 +4,7 @@ use function WP_CLI\Utils\make_progress_bar;
 use WP_Rocket\Engine\Cache\WPCache;
 
 /**
- * Manage Revisions
+ * Manage site performance, cache, preload, cdn...
  */
 class WPRocket_CLI extends WP_CLI_Command {
 	/**


### PR DESCRIPTION
When your run $ wp from a shell, you will see:

```
SUBCOMMANDS

  [...]
  rocket                Manage Revisions
  role                  Manages user roles, including creating new roles and resetting to defaults.
  [...]
```

I think this is a very old refuse.