### PR TITLE
[Enhancement] Add custom file output to settings export

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,8 @@ This repository contains a [WP-CLI command](https://github.com/wp-cli/wp-cli)  f
 * `wp rocket regenerate --file=<file>` -- Regenerate .htaccess, advanced-cache.php or the WP Rocket config file.
 * `wp rocket regenerate --file=config --nginx=true` -- regenerate the config file on Nginx hosts.
 * `wp rocket cdn --enable=<enable> --host=<host> --zone=<zone>` -- Enable / Disable CDN with the specified host and zone.
-* `wp rocket export` -- Exports the WP Rocket settings as a json file to the current directory.
+* `wp rocket export --output-file=<file_path>` -- Exports the WP Rocket settings as a json file to the current directory
+or to the specified file path. 
 * `wp rocket import --file=settings.json` -- Imports the settings contained in the provided json file.
 
 ## Installing

--- a/command.php
+++ b/command.php
@@ -455,10 +455,18 @@ class WPRocket_CLI extends WP_CLI_Command {
 
 	/**
 	 * Export Settings.
+	 * 
+	 *  ## OPTIONS
+	 *
+	 * [--output-file=<file_path>]
+	 * : The path where the exported json should be written:
+	 *  - example.json
+	 *  - /tmp/example.json
 	 *
 	 * ## EXAMPLES
 	 *
 	 *     wp rocket export
+	 * 	   wp rocket export --output-file=wp-settings-site-1.json
 	 *
 	 * @subcommand export
 	 */
@@ -467,20 +475,20 @@ class WPRocket_CLI extends WP_CLI_Command {
 		if ( ! is_plugin_active( 'wp-rocket/wp-rocket.php' ) ) {
 			WP_CLI::error( 'WP Rocket is not enabled.' );
 		}
-
-		$filename = sprintf( 'wp-rocket-settings-%s-%s.json', date( 'Y-m-d' ), uniqid() ); // phpcs:ignore WordPress.DateTime.RestrictedFunctions.date_date
-		$gz       = 'gz' . strrev( 'etalfed' );
+		$filename = $assoc_args['output-file'] ? $assoc_args['output-file'] : false;
+		if(!$filename){
+			$filename = sprintf( 'wp-rocket-settings-%s-%s.json', date( 'Y-m-d' ), uniqid() ); // phpcs:ignore WordPress.DateTime.RestrictedFunctions.date_date
+		}
 		$options  = wp_json_encode( get_option( 'wp_rocket_settings' ) );
 
 		$file = fopen( $filename, 'w' );
 		$res  = fwrite( $file, $options );
 		if ( false === $res ) {
-			WP_CLI::error( 'Export: error writing to export file.' );
+			WP_CLI::error( 'Export: error writing to export file '. $filename );
 		} else {
 			WP_CLI::success( 'Successfully exported in ' . $filename );
 		}
 		fclose( $file );
-
 	}
 
 	/**


### PR DESCRIPTION
## Description

1. Currently you cannot export the configuration to a specific file and the generated file name is random.
2. This makes it very hard to use in scripts. For example if you want to export the settings and import them again in several sites. 
3. Motivation: Be able to export / import settings across multiple sites in your wordpress network to avoid manual work.

I've added a parameter `--output-file` to `wp rocket export` so the user can choose where the file will be written. Leaving the parameter empty still works so the original functionality remains intact. 

## Type of change

*Please delete options that are not relevant.*

- Enhancement (non-breaking change which improves an existing functionality).


## Is the solution different from the one proposed during the grooming?



# Checklists

## Generic development checklist

- [ ] My code follows the style guidelines of this project, with adapted comments and without new warnings.
- [ ] I have added unit and integration tests that prove my fix is effective or that my feature works.
- [ ] The CI passes locally with my changes (including unit tests, integration tests, linter).
- [ ] Any dependent changes have been merged and published in downstream modules.
- [ ] If applicable, I have made corresponding changes to the documentation. *Provide a link to the documentation.*

## Test summary

- [ ] I triggered all changed lines of code at least once without new errors/warnings/notices.
- [ ] I validated all Acceptance Criteria of the related issues. (If applicable, provide proof).
- [ ] I validated all test plan the QA Review asked me to.

```bash
~ wp rocket export --output-file=asd.json
Success: Successfully exported in asd.json
~ wp rocket export --output-file=/tmp/asd.json
Success: Successfully exported in /tmp/asd.json
~ wp rocket export --output-file=../asd.json
Success: Successfully exported in ../asd.json
```

*If not, detail what you could not test.*

*Please describe any additional tests you performed.*
